### PR TITLE
Update default branch from master to main in weekly report workflow

### DIFF
--- a/.github/workflows/generate-weekly-report.yaml
+++ b/.github/workflows/generate-weekly-report.yaml
@@ -64,7 +64,7 @@ jobs:
         with:
           repository: gentoo/gentoo
           path: gentoo
-          ref: main
+          ref: master
           fetch-depth: 20000
       - name: Run reports
         if: steps.validate-dates.outputs.ok == 1

--- a/.github/workflows/generate-weekly-report.yaml
+++ b/.github/workflows/generate-weekly-report.yaml
@@ -8,7 +8,7 @@ on:
       target_branch:
         type: string
         required: false
-        default: master
+        default: main
         description: |
           The name of a branch with the generated report to be pushed.
 
@@ -64,7 +64,7 @@ jobs:
         with:
           repository: gentoo/gentoo
           path: gentoo
-          ref: master
+          ref: main
           fetch-depth: 20000
       - name: Run reports
         if: steps.validate-dates.outputs.ok == 1
@@ -90,4 +90,4 @@ jobs:
           git config user.email 'buildbot@flatcar.org'
           git add "${DATE}"
           git commit -m "Report for ${DATE}"
-          git push origin "HEAD:${TARGET_BRANCH:-master}"
+          git push origin "HEAD:${TARGET_BRANCH:-main}"


### PR DESCRIPTION
This pull request updates the default branch name from `master` to `main` in the workflow configuration file `.github/workflows/generate-weekly-report.yaml`. The changes ensure consistency with modern naming conventions.

Branch name updates in workflow configuration:

* Updated the default value of `target_branch` from `master` to `main` in the `on:` section. (`[.github/workflows/generate-weekly-report.yamlL11-R11](diffhunk://#diff-845b0f86abfed51adc5af40f1be3b54c017be4c69b0146b28db88fc3349788e2L11-R11)`)
* Changed the `ref` parameter from `master` to `main` in the `jobs:` section for repository checkout. (`[.github/workflows/generate-weekly-report.yamlL67-R67](diffhunk://#diff-845b0f86abfed51adc5af40f1be3b54c017be4c69b0146b28db88fc3349788e2L67-R67)`)
* Updated the `git push` command to use `main` as the default branch instead of `master`. (`[.github/workflows/generate-weekly-report.yamlL93-R93](diffhunk://#diff-845b0f86abfed51adc5af40f1be3b54c017be4c69b0146b28db88fc3349788e2L93-R93)`)

Part of:  https://github.com/flatcar/Flatcar/issues/1714