### PR TITLE
Update generate-weekly-report.yaml to use signed commits

### DIFF
--- a/.github/workflows/generate-weekly-report.yaml
+++ b/.github/workflows/generate-weekly-report.yaml
@@ -89,5 +89,5 @@ jobs:
           git config user.name 'Flatcar Buildbot'
           git config user.email 'buildbot@flatcar.org'
           git add "${DATE}"
-          git commit -m "Report for ${DATE}"
+          git commit -s -m "Report for ${DATE}"
           git push origin "HEAD:${TARGET_BRANCH:-main}"

--- a/.github/workflows/generate-weekly-report.yaml
+++ b/.github/workflows/generate-weekly-report.yaml
@@ -90,4 +90,4 @@ jobs:
           git config user.email 'buildbot@flatcar.org'
           git add "${DATE}"
           git commit -s -m "Report for ${DATE}"
-          git push origin "HEAD:${TARGET_BRANCH:-main}"
+          git push --force origin "HEAD:${TARGET_BRANCH:-main}"


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/generate-weekly-report.yaml` file to improve commit signing in the workflow.

* `jobs:` in `.github/workflows/generate-weekly-report.yaml`: Updated the `git commit` command to include the `-s` flag, ensuring that commits are signed off as required by contribution guidelines.